### PR TITLE
chore(postgres) update postgres version to 16

### DIFF
--- a/postgres/compose.yml
+++ b/postgres/compose.yml
@@ -1,7 +1,7 @@
 
 services:
     db:
-        image: postgres:16.4
+        image: postgres:16
         container_name: videodl-db
         restart: unless-stopped
         env_file:
@@ -13,3 +13,4 @@ services:
 
 volumes:
     videodl-db-data:
+


### PR DESCRIPTION
We want to use postgres 16 but always the latest version of the 16.x series. Upgraded tag in docker-compose.yml to 16.